### PR TITLE
support insecure option

### DIFF
--- a/cmd/buildview.go
+++ b/cmd/buildview.go
@@ -2,15 +2,17 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/concaf/cumin/pkg/dashboard"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-	"log"
-	"strings"
 )
 
 var (
 	buildURL                string
+	insecureBuildURL        bool
 	viewGenerateNum         int
 	viewLastSuccessfulBuild bool
 	getIndexImages          bool
@@ -21,7 +23,7 @@ var buildViewCmd = &cobra.Command{
 	Use:   "build-view",
 	Short: "jenkins build view",
 	Run: func(cmd *cobra.Command, args []string) {
-		buildViews, err := dashboard.GenerateBuildViews(buildURL, jenkinsUsername, jenkinsPassword, viewGenerateNum)
+		buildViews, err := dashboard.GenerateBuildViews(buildURL, insecureBuildURL, jenkinsUsername, jenkinsPassword, viewGenerateNum)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -41,7 +43,7 @@ var buildViewCmd = &cobra.Command{
 			splitUrl = append(splitUrl, "lastSuccessfulBuild")
 			lastSuccessfulUrl := strings.Join(splitUrl, "/")
 
-			lastSuccessfulView, err := dashboard.GetBuildView(lastSuccessfulUrl, jenkinsUsername, jenkinsPassword)
+			lastSuccessfulView, err := dashboard.GetBuildView(lastSuccessfulUrl, insecureBuildURL, jenkinsUsername, jenkinsPassword)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -77,6 +79,7 @@ func init() {
 
 	buildViewCmd.Flags().StringVar(&buildURL, "build", "", "url for the jenkins build")
 	buildViewCmd.MarkFlagRequired("build")
+	buildViewCmd.Flags().BoolVar(&insecureBuildURL, "insecure", true, "insecure skip verify")
 	buildViewCmd.Flags().IntVar(&viewGenerateNum, "generate-num", 3, "number of views to generate")
 	buildViewCmd.Flags().BoolVar(&viewLastSuccessfulBuild, "last-successful-build", true, "do you want to generate the last successful build as well?")
 	buildViewCmd.Flags().BoolVar(&getIndexImages, "index-images", false, "get index images for cvp job urls?")

--- a/cmd/e2eflow.go
+++ b/cmd/e2eflow.go
@@ -5,10 +5,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/concaf/cumin/pkg/dashboard"
-	"gopkg.in/yaml.v3"
 	"log"
 	"net/url"
+
+	"github.com/concaf/cumin/pkg/dashboard"
+	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,7 @@ import (
 var (
 	baseUrl             string
 	cvpUrl              string
+	insecureFlowUrl     bool
 	checkMergedNum      string
 	generateNum         int
 	lastSuccessfulBuild bool
@@ -30,7 +32,7 @@ var e2eflowCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		e2eFlow, err := dashboard.GenerateEndToEndFlow(jenkinsUsername, jenkinsPassword, baseUrl, cvpUrl, checkMergedUrl, generateNum)
+		e2eFlow, err := dashboard.GenerateEndToEndFlow(jenkinsUsername, jenkinsPassword, baseUrl, cvpUrl, checkMergedUrl, insecureFlowUrl, generateNum)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -48,7 +50,7 @@ var e2eflowCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			lastSuccessfulFlow, err := dashboard.GenerateEndToEndFlowSingle(jenkinsUsername, jenkinsPassword, baseUrl, cvpUrl, lastSuccessfulUrl)
+			lastSuccessfulFlow, err := dashboard.GenerateEndToEndFlowSingle(jenkinsUsername, jenkinsPassword, baseUrl, cvpUrl, lastSuccessfulUrl, insecureFlowUrl)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -72,6 +74,8 @@ func init() {
 
 	e2eflowCmd.Flags().StringVar(&cvpUrl, "cvp", "", "url of cvp jenkins, e.g. https://<jenkins url>/view/all/job/cvp-redhat-operator-bundle-image-validation-test/")
 	e2eflowCmd.MarkFlagRequired("cvp")
+
+	e2eflowCmd.Flags().BoolVar(&insecureFlowUrl, "insecure", true, "disables SSL certificate verification")
 
 	e2eflowCmd.Flags().StringVar(&checkMergedNum, "check-merged", "lastBuild", "number of check-merged job")
 	e2eflowCmd.Flags().IntVar(&generateNum, "generate-num", 3, "number of builds to generate")


### PR DESCRIPTION
With this PR,
* by default the `cumin` client accepts insecure url (example: self signed SSL)
* user can pass: `--insecure=false`, to enable SSL certificate verification
* supports `--insecure` on `buildview` and `e2eflow`